### PR TITLE
Define STRICT_R_HEADERS*, use M_PI

### DIFF
--- a/src/simulations_1.5.cpp
+++ b/src/simulations_1.5.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 #include <vector>
 #include <iostream>
@@ -302,7 +303,7 @@ DataFrame fixed_area_cpp(std::vector<double> radius_seq,
 
     factor.assign(weights.begin(), weights.begin()
                                    + distance(hdist.begin(), pos));
-    ef = 10000 / (PI * pow(radius_seq[i], 2.0));
+    ef = 10000 / (M_PI * pow(radius_seq[i], 2.0));
     transform(factor.begin(), factor.end(), factor.begin(),
               std::bind(multiplies<double>(), std::placeholders::_1, ef));
     partial_sum(factor.begin(), factor.end(), factor.begin());
@@ -398,7 +399,7 @@ DataFrame k_tree_cpp(std::vector<double> k_seq,
 
     factor.assign(weights.begin(), weights.begin()
                                    + distance(k.begin(), pos));
-    ef = 10000 / (PI * pow(radius_seq[i], 2.0));
+    ef = 10000 / (M_PI * pow(radius_seq[i], 2.0));
     transform(factor.begin(), factor.end(), factor.begin(),
               std::bind(multiplies<double>(), std::placeholders::_1, ef));
     partial_sum(factor.begin(), factor.end(), factor.begin());
@@ -496,7 +497,7 @@ DataFrame angle_count_cpp(std::vector<double> baf_seq,
                                    + distance(baf.begin(), pos));
     ef = baf_seq[i];
     transform(factor.begin(), factor.end(), x.begin(), factor.begin(),
-              [ef](double factor, double x) { return ef / ((PI / 4) *
+              [ef](double factor, double x) { return ef / ((M_PI / 4) *
                                               pow(x, 2.0)); });
 
     for(int q = 0; q < factor.size(); q++){

--- a/src/surface_variation_1.3.cpp
+++ b/src/surface_variation_1.3.cpp
@@ -1,4 +1,5 @@
 
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 #include <RcppEigen.h>
 


### PR DESCRIPTION
Dear Jean Alberto,

Your CRAN package FORTLS uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context on this.

Here, we prefed each #include <Rcpp.h> with STRICT_R_HEADERS. The actual change that is needed is the change from PI to M_PI in one file. 

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by  https://github.com/RcppCore/Rcpp/issues/1158 to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.