### PR TITLE
`vroom_write(path =)` has been removed, in favor of `vroom_write(file =)`

### DIFF
--- a/R/normalize.R
+++ b/R/normalize.R
@@ -463,7 +463,7 @@ normalize <- function(las, normalized = NULL,
 
     .data.red <- .data[which(.data$prob.selec == 1), , drop = FALSE]
 
-    vroom::vroom_write(.data.red, path = file.path(dir.result, .data.red$file[1]), delim = ",", progress = FALSE)
+    vroom::vroom_write(.data.red, file = file.path(dir.result, .data.red$file[1]), delim = ",", progress = FALSE)
 
   }
 


### PR DESCRIPTION
The `path` argument will be removed from `vroom::vroom_write()` in its next release, which is imminent (I am under deadline). `vroom_write(path =)` was deprecated in vroom 1.5.0 (2021-06-14), in favor of the `file` parameter (#575).

I ran revdep checks on 2025-12-01, because I knew I was planning a vroom release, but apparently FORTLS had fallen off of CRAN at that point and could not be checked by our system. FORTLS has recently reappeared on CRAN, which is why you're getting rather late notice. But this code has been producing a deprecation warning for over 4 years.